### PR TITLE
feat16: agregar movimiento de puerta

### DIFF
--- a/main_menu.gd
+++ b/main_menu.gd
@@ -9,6 +9,11 @@ func _ready():
 	start_button.pressed.connect(_on_start_button_pressed)
 	options_button.pressed.connect(_on_options_button_pressed)
 	quit_button.pressed.connect(_on_quit_button_pressed)
+	
+	# Detener la música del juego si está sonando
+	var global_audio_manager = get_node("/root/GlobalAudioManager")
+	if global_audio_manager:
+		global_audio_manager.stop_game_music()
 
 func _on_start_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/intro/intro_historia.tscn")

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 Global="*res://globals/Global.gd"
+GlobalAudioManager="*res://scenes/game/global_audio_manager.tscn"
 
 [display]
 

--- a/scenes/final/fin_exitoso.gd
+++ b/scenes/final/fin_exitoso.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	# Detener la música del juego si está sonando
+	var global_audio_manager = get_node("/root/GlobalAudioManager")
+	if global_audio_manager:
+		global_audio_manager.stop_game_music()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scenes/final/fin_exitoso.tscn
+++ b/scenes/final/fin_exitoso.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=4 format=3 uid="uid://bty6sfwj70to2"]
+[gd_scene load_steps=5 format=3 uid="uid://bty6sfwj70to2"]
 
 [ext_resource type="Texture2D" uid="uid://qps8j1pobqup" path="res://assets/images/game_end_screen.png" id="1_2jt6s"]
+[ext_resource type="Script" path="res://scenes/final/fin_exitoso.gd" id="1_cwyl6"]
 [ext_resource type="Theme" uid="uid://b0no6xio07hgv" path="res://assets/themes/end_screen_theme.tres" id="2_sijk6"]
 [ext_resource type="Script" path="res://assets/scripts/AudioLoopBase.gd" id="3_jk7oi"]
 
 [node name="Final" type="Node2D"]
+script = ExtResource("1_cwyl6")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(960, 540)

--- a/scenes/game/global_audio_manager.gd
+++ b/scenes/game/global_audio_manager.gd
@@ -1,0 +1,25 @@
+extends Node
+
+@export var game_music_path: String
+@onready var audio_player: AudioStreamPlayer = $AudioStreamPlayer
+
+func _ready():
+	if audio_player:
+		if not audio_player.stream:
+			audio_player.stream = load(game_music_path)
+		audio_player.connect("finished", Callable(self, "_on_audio_finished"))
+		audio_player.play()
+
+func _on_audio_finished():
+	if audio_player:
+		audio_player.play()
+		
+func start_game_music():
+	if audio_player:
+		if not audio_player.is_playing():
+			audio_player.play()
+
+func stop_game_music():
+	if audio_player:
+		if audio_player.is_playing():
+			audio_player.stop()

--- a/scenes/game/global_audio_manager.tscn
+++ b/scenes/game/global_audio_manager.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://cv11blndwv7rg"]
+
+[ext_resource type="Script" path="res://scenes/game/global_audio_manager.gd" id="1_n83su"]
+
+[node name="GlobalAudioManager" type="Node2D"]
+script = ExtResource("1_n83su")
+game_music_path = "res://addons/sounds/GAME_PLAY_dream-nebula-lofi-228369.wav"
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]

--- a/scenes/game/nave_interior.gd
+++ b/scenes/game/nave_interior.gd
@@ -39,6 +39,11 @@ var ultimo_sprite = null  # Almacena el último sprite seleccionado para evitar 
 #var sprite_clickeado = false  
 
 func _ready():
+	var global_audio_manager = get_node("/root/GlobalAudioManager")
+	if global_audio_manager:
+		global_audio_manager.start_game_music()
+		
+	ocultar_todas_las_anomalias()
 	Global.sprite_clickeado = false  # Resetea la variable al iniciar la escena
 	Global.sprite_anomalianull = sprite_anomalianull
 	
@@ -67,12 +72,13 @@ func seleccionar_sprite_aleatorio():
 			Global.sprite_seleccionado = null
 			ultimo_sprite = Global.sprite_seleccionado
 			#Global.sprite_seleccionado = sprite_seleccionado
-			sprite_anomalia1.visible = false
-			sprite_anomalia2.visible = false
-			sprite_anomalia3.visible = false
-			sprite_anomalianull.visible = false
+			ocultar_todas_las_anomalias()
 
-
+func ocultar_todas_las_anomalias():
+	sprite_anomalia1.visible = false
+	sprite_anomalia2.visible = false
+	sprite_anomalia3.visible = false
+	sprite_anomalianull.visible = false
 	# Seleccionar aleatoriamente una textura para el sprite seleccionado
 	#if Global.sprite_seleccionado == sprite_anomalia1:
 	#	sprite_anomalia1.texture = texturas_anomalia1[randi() % texturas_anomalia1.size()]
@@ -125,6 +131,8 @@ func _on_button_anterior_pressed():
 	cambiar_fondo_actual()
 
 func _on_final_button_pressed():
+	puerta_rect.visible = false
+	
 	if Global.sprite_seleccionado != null:
 		# Mueve el sprite al nodo raíz para que no se libere al cambiar de escena
 		Global.sprite_seleccionado.get_parent().remove_child(Global.sprite_seleccionado)

--- a/scenes/game/nave_interior.gd
+++ b/scenes/game/nave_interior.gd
@@ -9,6 +9,7 @@ var fondos = [
 var indice_actual = 0  # Índice del fondo actual
 
 @onready var background_rect = $BackgroundRect
+@onready var puerta_rect = $PuertaTextureRect
 @onready var final_button = $FinalButton  
 #sprite anomalias
 @onready var sprite_anomalia1 = $SpriteAnomalia1
@@ -100,11 +101,14 @@ func cambiar_fondo_actual():
 		sprite_anomalia2.visible = true
 	elif indice_actual == 2 and Global.sprite_seleccionado == sprite_anomalia3:
 		sprite_anomalia3.visible = true
+		
 
 	# Verificar si estamos en la última imagen
 	if indice_actual == fondos.size() - 1:
+		puerta_rect.visible = true
 		final_button.visible = true
 	else:
+		puerta_rect.visible = false
 		final_button.visible = false
 
 # Funciones de los botones
@@ -125,7 +129,11 @@ func _on_final_button_pressed():
 		# Mueve el sprite al nodo raíz para que no se libere al cambiar de escena
 		Global.sprite_seleccionado.get_parent().remove_child(Global.sprite_seleccionado)
 		get_tree().root.add_child(Global.sprite_seleccionado)
-		
+	
+	#1. Aparecer modal con opciones..
+	#2. Si hace click en quedarse a descansar.... mostrar sala de comando, anomalia no debe estar en el 1er cuadro
+	#3. Si hace click en salir de la sala, hacer animacion de la puerta
+
 	get_tree().change_scene_to_file("res://scenes/game/nave_puerta_decision.tscn")
 	final_button.visible = false
 	

--- a/scenes/game/nave_interior.tscn
+++ b/scenes/game/nave_interior.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://c70ehhd5aau5n"]
+[gd_scene load_steps=7 format=3 uid="uid://c70ehhd5aau5n"]
 
 [ext_resource type="Script" path="res://scenes/game/nave_interior.gd" id="1_pfqr7"]
 [ext_resource type="Theme" uid="uid://c1v7gva6oakb1" path="res://assets/themes/game_play_theme.tres" id="2_2w4yl"]
@@ -6,7 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://enxr0opqq1l3" path="res://assets/images/sala_de_comando_scene/silla1.png" id="3_06k5f"]
 [ext_resource type="Texture2D" uid="uid://b74pp0l6s8bqp" path="res://assets/images/vitrina_scene/alien1.png" id="4_gfd07"]
 [ext_resource type="Texture2D" uid="uid://drcr7k514uat1" path="res://assets/images/puerta_scene/flor0.png" id="5_brquh"]
-[ext_resource type="Script" path="res://assets/scripts/AudioLoopBase.gd" id="6_8ctk8"]
 
 [node name="Node2D" type="Node2D"]
 metadata/_edit_horizontal_guides_ = [540.0, -194.0]
@@ -95,12 +94,6 @@ theme_override_colors/font_color = Color(0.168627, 1, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 15
 theme_override_font_sizes/font_size = 100
-
-[node name="AudioManager" type="Node" parent="Control"]
-script = ExtResource("6_8ctk8")
-audio_file_path = "res://addons/sounds/GAME_PLAY_dream-nebula-lofi-228369.wav"
-
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="Control/AudioManager"]
 
 [connection signal="pressed" from="Control/ButtonSiguiente" to="Control" method="_on_button_siguiente_pressed"]
 [connection signal="pressed" from="Control/ButtonAnterior" to="Control" method="_on_button_anterior_pressed"]

--- a/scenes/game/nave_interior.tscn
+++ b/scenes/game/nave_interior.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://c70ehhd5aau5n"]
+[gd_scene load_steps=8 format=3 uid="uid://c70ehhd5aau5n"]
 
 [ext_resource type="Script" path="res://scenes/game/nave_interior.gd" id="1_pfqr7"]
 [ext_resource type="Theme" uid="uid://c1v7gva6oakb1" path="res://assets/themes/game_play_theme.tres" id="2_2w4yl"]
+[ext_resource type="Texture2D" uid="uid://dyisqjy7jw1jp" path="res://assets/images/puerta_scene/puerta.png" id="2_vir5p"]
 [ext_resource type="Texture2D" uid="uid://enxr0opqq1l3" path="res://assets/images/sala_de_comando_scene/silla1.png" id="3_06k5f"]
 [ext_resource type="Texture2D" uid="uid://b74pp0l6s8bqp" path="res://assets/images/vitrina_scene/alien1.png" id="4_gfd07"]
 [ext_resource type="Texture2D" uid="uid://drcr7k514uat1" path="res://assets/images/puerta_scene/flor0.png" id="5_brquh"]
@@ -24,6 +25,14 @@ offset_right = 1920.0
 offset_bottom = 1080.0
 expand_mode = 3
 stretch_mode = 4
+
+[node name="PuertaTextureRect" type="TextureRect" parent="Control"]
+visible = false
+z_index = -1
+layout_mode = 0
+offset_right = 1920.0
+offset_bottom = 1080.0
+texture = ExtResource("2_vir5p")
 
 [node name="ButtonSiguiente" type="Button" parent="Control"]
 layout_mode = 0

--- a/scenes/game/nave_puerta_decision.gd
+++ b/scenes/game/nave_puerta_decision.gd
@@ -1,5 +1,6 @@
 extends Node2D
 
+@onready var puerta_rect = $PuertaTextureRect
 @onready var boton_no_hay_nada = $Button_NoHayNada
 @onready var boton_hay_algo = $Button_HayAlgo
 
@@ -17,6 +18,10 @@ func _on_button_no_hay_nada_pressed():
 		player_acumula_aciertos()
 
 func _on_button_hay_algo_pressed():
+	$AnimationPlayer.play("deslizar_puerta_animation")
+	# Espera 1 segundo antes de continuar
+	await get_tree().create_timer(1.0).timeout
+	
 	Global.player_eligio_descansar = false
 	if Global.sprite_seleccionado != null and Global.sprite_seleccionado != Global.sprite_anomalianull:
 		player_acumula_aciertos()

--- a/scenes/game/nave_puerta_decision.tscn
+++ b/scenes/game/nave_puerta_decision.tscn
@@ -1,17 +1,59 @@
-[gd_scene load_steps=5 format=3 uid="uid://d3afi03x3ixuc"]
+[gd_scene load_steps=9 format=3 uid="uid://d3afi03x3ixuc"]
 
 [ext_resource type="Script" path="res://scenes/game/nave_puerta_decision.gd" id="1_xpj76"]
 [ext_resource type="Theme" uid="uid://c1v7gva6oakb1" path="res://assets/themes/game_play_theme.tres" id="2_nfum6"]
 [ext_resource type="Texture2D" uid="uid://bebgcu87jrvw8" path="res://assets/images/puerta_scene/screen.png" id="2_o6i8s"]
+[ext_resource type="Texture2D" uid="uid://dyisqjy7jw1jp" path="res://assets/images/puerta_scene/puerta.png" id="3_0g32e"]
 [ext_resource type="StyleBox" uid="uid://htyws5di1vfl" path="res://assets/themes/game_play_dialogo_buttons.tres" id="3_mwcim"]
+
+[sub_resource type="Animation" id="Animation_4ht1o"]
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("PuertaTextureRect:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(15, 0), Vector2(30, 0), Vector2(45, 0), Vector2(60, 0), Vector2(75, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_sltxm"]
+resource_name = "deslizar_puerta_animation"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("PuertaTextureRect:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(20, 0), Vector2(40, 0), Vector2(60, 0), Vector2(80, 0), Vector2(100, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_07b1r"]
+_data = {
+"RESET": SubResource("Animation_4ht1o"),
+"deslizar_puerta_animation": SubResource("Animation_sltxm")
+}
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource("1_xpj76")
 
-[node name="TextureRect" type="TextureRect" parent="."]
+[node name="PanelPuertaTextureRect" type="TextureRect" parent="."]
 offset_right = 1920.0
 offset_bottom = 1080.0
 texture = ExtResource("2_o6i8s")
+
+[node name="PuertaTextureRect" type="TextureRect" parent="."]
+z_index = -1
+offset_right = 1920.0
+offset_bottom = 1080.0
+texture = ExtResource("3_0g32e")
 
 [node name="TextEdit" type="TextEdit" parent="."]
 anchors_preset = 15
@@ -51,3 +93,8 @@ text = "Salir de la sala"
 wait_time = 2.0
 one_shot = true
 autostart = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_07b1r")
+}

--- a/scenes/game/nave_sala_descansar.gd
+++ b/scenes/game/nave_sala_descansar.gd
@@ -1,15 +1,21 @@
 extends Node2D
-@onready var boton_continuar = $Button
+
 @onready var descansar_prompt : TextEdit = $PromptText
 
-func _ready():
-	# Conectar el botón "CONTINUAR" a la función que cambiará la escena (NECESARIO!!! no solamente el fun on press)
-	boton_continuar.connect("pressed", Callable(self, "_on_button_pressed"))
+var escena_nave_interior = preload("res://scenes/game/nave_interior.tscn")
 
+func _ready():
 	if Global.player_eligio_descansar:
 		descansar_prompt.text = "Descansaré en la sala de comandos, a ver que pasa..."
 	else:
 		descansar_prompt.text = "Saliendo de la sala de comandos."
+	
+	# Esperar 2 segundos y luego cambiar de escena
+	await get_tree().create_timer(2.0).timeout
+	_on_timer_timeout()
 
-func _on_button_pressed():
-	get_tree().change_scene_to_file("res://scenes/game/nave_interior.tscn")
+func _on_timer_timeout():
+	# Instanciar la escena precargada y cambiar a ella
+	var nueva_escena = escena_nave_interior.instantiate()
+	get_tree().current_scene.queue_free()  # Opcional: libera la escena actual
+	get_tree().get_root().add_child(nueva_escena)

--- a/scenes/game/nave_sala_descansar.tscn
+++ b/scenes/game/nave_sala_descansar.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://c2bcb1k0uo8gx"]
+[gd_scene load_steps=4 format=3 uid="uid://c2bcb1k0uo8gx"]
 
 [ext_resource type="Script" path="res://scenes/game/nave_sala_descansar.gd" id="1_cfkm7"]
 [ext_resource type="Texture2D" uid="uid://b225ckqqh2nve" path="res://assets/images/sala_de_comando_scene/screen.png" id="2_3wcgf"]
 [ext_resource type="Theme" uid="uid://c1v7gva6oakb1" path="res://assets/themes/game_play_theme.tres" id="3_qkdqd"]
-[ext_resource type="StyleBox" uid="uid://htyws5di1vfl" path="res://assets/themes/game_play_dialogo_buttons.tres" id="4_8s4km"]
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource("1_cfkm7")
@@ -17,20 +16,9 @@ texture = ExtResource("2_3wcgf")
 
 [node name="PromptText" type="TextEdit" parent="."]
 offset_left = 560.0
-offset_top = 340.0
+offset_top = 240.0
 offset_right = 1360.0
-offset_bottom = 740.0
+offset_bottom = 440.0
 theme = ExtResource("3_qkdqd")
 text = "Descansaré en la sala de comandos, a ver que pasa..."
 wrap_mode = 1
-
-[node name="Button" type="Button" parent="."]
-offset_left = 816.0
-offset_top = 619.0
-offset_right = 1104.0
-offset_bottom = 699.0
-theme = ExtResource("3_qkdqd")
-theme_override_font_sizes/font_size = 72
-theme_override_styles/normal = ExtResource("4_8s4km")
-text = "CONTINUAR
-"


### PR DESCRIPTION
- Se agregó animación de deslizamiento de la puerta.
- Los modales que aparecen indicando que va a salir de la sala o va a quedarse a descansar fueron actualizados:
> - botón de interacción eliminado
> - el modal desaparece a los 2.0sec 
- El audio entre paneles 1, 2 y 3 ahora es continuo


https://github.com/user-attachments/assets/192dd644-c497-4646-8c10-557b4c1c8d23


